### PR TITLE
Fixes community calls index link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you'd like to join the community and help improve these tools, great!
 
 Join us Thursdays at 6:30 ET (Eastern Time) at our [**weekly community standup call**](https://zoom.us/j/508236833): [zoom.us/j/508236833](https://zoom.us/j/508236833), call link also posted in slack and on our [events calendar](https://envirodatagov.org/events/).
 
-**Recent Calls:** If you've missed a call check out our [recorded meetings](https://www.youtube.com/watch?v=-A7pep7iXw8&list=PLtsP3g9LafVsaa18lQaPXzxJU7wIcPB1O)!
+**Recent Calls:** If you've missed a call check out our [recorded meetings](https://www.youtube.com/playlist?list=PLtsP3g9LafVsaa18lQaPXzxJU7wIcPB1O)!
 
 ## Projects
 


### PR DESCRIPTION
The previous link goes to a particular video (April 27) and not the index.