### PR TITLE
removes table of contents from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ Our GitHub organization, chat, and in-person events have a [Code of Conduct](/CO
 
 ---
 
-## Table of Contents
-
-- [Get Involved](#get-involved)
-- [Projects](#projects)
-- [Roadmap](#roadmap)
-- [Working Openly](#working-openly)
-
 ## Get Involved
 
 Welcome to our community! We welcome contributors from many skillsets. Here's how to get started:


### PR DESCRIPTION
I realized I'd accidentally left a ToC item for Roadmap despite the section being deleted.

Decided to remove the whole table of contents because the Readme is really not that big/it's faster to just scroll and look at it.