### PR TITLE
Set up Github sponsorship button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+custom: 'https://secure.lglforms.com/form_engine/s/pSsqtc9u4WVkEonQbBbU8Q'
+
+## Also supported, but we don't currently use them:
+# github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+# patreon: # Replace with a single Patreon username
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# otechie: # Replace with a single Otechie username


### PR DESCRIPTION
The built-in sponsorship button on Github runs off the `FUNDING.yml` config file. I've seeded it here with the same donations link we use in the README. More info on configuration at: https://help.github.com/articles/displaying-a-sponsor-button-in-your-repository

This is basically a follow-on to #232.

If people think this config makes sense, I’ll add it to the Web Monitoring overview repo, too. (Or maybe all our active repos?)