### PR TITLE
Add explicit info about PR review process & time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,13 @@ Our process for accepting changes operates by [Pull Request (PR)](https://help.g
 
     In general, we do our best to provide some feedback or review within about 3 days. (And hopefully much quicker most of the time!)
     
-    If you have commit rights on a repo, you are generally expected to merge your own PR, but you should allow up to 3 days for someone to review it first. If nobody’s had time to review it by then, you can go ahead and merge it. If you have a *hotfix* that needs to get merged ASAP ([see below](#hotfixes)), please bug someone on Slack to try and review it quickly, but you may merge without review if nobody can. On the other hand, you might have a deeply drastic change that would break everyone’s development environment and needs extra time above and beyond 3 days for others to review. There aren’t hard rules here—being given commit rights is a sign of trust that you’ll make reasonable decisions. When in doubt, opt for more time & feedback rather than less.
+    If you have commit rights on the repo, you should merge your own PR, but have someone else review it first:
+    
+    - Allow up to 3 days for review. If you don’t get any feedback by then, you can merge it without review.
+    
+    - If you have a urgent *hotfix* ([see below](#hotfixes)), please bug someone on Slack for rapid review, but you may merge without if nobody can.
+    
+    - If you have a drastic change (e.g., one that might break everyone’s development environment), consider allowing extra time beyond 3 days for others to review. There aren’t hard rules here—being given commit rights is a sign of trust that you’ll make reasonable decisions. When in doubt, opt for more time & feedback rather than less.
     
     Anyone with commit rights can review, but you are expected to be reasonable about whether you *should.* For example, you should probably ask someone else to review if you don’t know much about the part of the codebase being worked on. If you are reviewing a PR, think about whether others need to review it in addition to you and request them through GitHub or poke them on Slack.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,23 @@ Our process for accepting changes operates by [Pull Request (PR)](https://help.g
 
 1.  Allow others sufficient **time for review and comments** before merging. We make use of GitHub's review feature to comment in-line on PRs when possible. There may be some fixes or adjustments you'll have to make based on feedback.
 
-1.  Once you have integrated comments, or waited for feedback, a Lieutenant should merge your changes in!
+    In general, we do our best to provide some feedback or review within about 3 days. (And hopefully much quicker most of the time!)
+    
+    If you have commit rights on a repo, you are generally expected to merge your own PR, but you should allow up to 3 days for someone to review it first. If nobody’s had time to review it by then, you can go ahead and merge it. If you have a *hotfix* that needs to get merged ASAP ([see below](#hotfixes)), please bug someone on Slack to try and review it quickly, but you may merge without review if nobody can. On the other hand, you might have a deeply drastic change that would break everyone’s development environment and needs extra time above and beyond 3 days for others to review. There aren’t hard rules here—being given commit rights is a sign of trust that you’ll make reasonable decisions. When in doubt, opt for more time & feedback rather than less.
+    
+    Anyone with commit rights can review, but you are expected to be reasonable about whether you *should.* For example, you should probably ask someone else to review if you don’t know much about the part of the codebase being worked on. If you are reviewing a PR, think about whether others need to review it in addition to you and request them through GitHub or poke them on Slack.
+
+1.  Once you have integrated comments, or waited for feedback, a Lieutenant should merge your changes in! If you have commit rights on a repo, you are generally expected to merge your own change, but please do not do so without someone else reviewing first (see above).
+
+    When merging PRs, we generally use the “squash and merge” feature on GitHub so that each PR has a single, clear commit, and so that the commit title links back to the PR by its number (e.g. [``Document `ALLOWED_ARCHIVE_HOSTS` and S3 Buckets (#595)``](https://github.com/edgi-govdata-archiving/web-monitoring-db/commit/c79bde1556dd7e16de3b29e0849149ed01b30a9c)). Sometimes it makes sense to do an actual merge or a rebase, though. Choose what’s correct for the situation.
 
 _These guidelines are based on [Toronto Mesh](https://github.com/tomeshnet)'s._
+
+
+### Hotfixes
+
+A hotfix is a quick solution to an active, serious problem that is causing unrecoverable data loss, whole systems to be unavailable, etc. The hotfix may be the minimum intervention necessary to address the failure, but will likely not be ideal (since it needs to be designed, programmed, and deployed quickly). It **should** be reviewed by someone else, but may be merged and deployed without review if nobody is available within a short timeframe. The hotfix should almost always be reviewed again after deployment and, if necessary, a better long-term fix should be planned.
+
+To make the situation clear, you should prefix commit messages and PR titles with `HOTFIX:`.
+
+Here’s an example: a dependency update broke cross-origin requests for an API, meaning access from other webapps was completely cut off. A hotfix was issued in [`HOTFIX: Reflect origin header for CORS auth`](https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/126)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Our process for accepting changes operates by [Pull Request (PR)](https://help.g
 
 1.  Once you have integrated comments, or waited for feedback, a Lieutenant should merge your changes in! If you have commit rights on a repo, you are generally expected to merge your own change, but please do not do so without someone else reviewing first (see above).
 
-    When merging PRs, we generally use the “squash and merge” feature on GitHub so that each PR has a single, clear commit, and so that the commit title links back to the PR by its number (e.g. [``Document `ALLOWED_ARCHIVE_HOSTS` and S3 Buckets (#595)``](https://github.com/edgi-govdata-archiving/web-monitoring-db/commit/c79bde1556dd7e16de3b29e0849149ed01b30a9c)). Sometimes it makes sense to do an actual merge or a rebase, though. Choose what’s correct for the situation.
+    When merging PRs, we generally use the “squash and merge” feature on GitHub so that each PR has a single, clear commit, and so that the commit title links back to the PR by its number (e.g. [``Document `ALLOWED_ARCHIVE_HOSTS` and S3 Buckets (#595)``](https://github.com/edgi-govdata-archiving/web-monitoring-db/commit/c79bde1556dd7e16de3b29e0849149ed01b30a9c)). (This isn’t a *hard* rule. If you have a specific reason to do an actual merge or a rebase, then do so.)
 
 _These guidelines are based on [Toronto Mesh](https://github.com/tomeshnet)'s._
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We love improvements to our tools! There are a few key ways you can help us impr
 
 ### Submitting Feedback, Requests, and Bugs
 
-Our process for submitting feedback, feature requests, and reporting bugs usually begins by discussion on [our chat](https://github.com/edgi-govdata-archiving/overview#development) and, after initial clarification, through [GitHub issues](https://help.github.com/articles/about-issues/). Each project repository generally maintains its own set of issues:
+Our process for submitting feedback, feature requests, and reporting bugs usually begins by discussion on [our chat](https://github.com/edgi-govdata-archiving/overview#get-involved) and, after initial clarification, through [GitHub issues](https://help.github.com/articles/about-issues/). Each project repository generally maintains its own set of issues:
 
         https://github.com/edgi-govdata-archiving/<repository-name>/issues
 


### PR DESCRIPTION
We have a bunch of rules for PR reviewing/merging/timeframes we’ve talked through at various web monitoring meetings, but they’re otherwise just held in people’s (or maybe just my?) head. I’ve attempted to write them down more explicitly here. I’ve changed the format and organization from what I originally write in #224 so that it fits the structure we already had better, but let me know if that’s made it less clear.

Also totally open to a review of this process! It’s what we generally use in web monitoring, but we haven’t talked through it in a long time and never really wrote it down. This is as good an opportunity as any to poke holes in it. 😅

Fixes #224.