### PR TITLE
Update code of conduct to link to formally adopted new doc

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-EDGI's Code of Conduct can be found here: https://docs.google.com/document/d/1zqFPVjQ__x3tfcSlir-jeO7O-mcCh4oKyNNlJEpJMOU/edit?usp=sharing
+EDGI's Code of Conduct can be found here: [https://docs.google.com/document/d/1zqFPVjQ__x3tfcSlir-jeO7O-mcCh4oKyNNlJEpJMOU/edit?usp=sharing](https://docs.google.com/document/d/1zqFPVjQ__x3tfcSlir-jeO7O-mcCh4oKyNNlJEpJMOU/edit?usp=sharing)

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,14 +1,3 @@
 # Code of Conduct
 
-Online or off, Environmental Data & Governance Initiative (EDGI) is a harrassment-free environment for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion or technical skill level. We do not tolerate harassment of participants in any form.
-
-Harassment includes verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
-
-If a participant engages in harassing behaviour, the organizers may take any action they deem appropriate, including warning the offender or expulsion from events and online forums.
-
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the organizing team immediately.
-
-Organizers will be happy to help participants contact local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event. We value your participation!
-
-This document is based on a similar code from [Civic Tech Toronto](http://civictech.ca/about-us/), itself derived from the [Recurse Center’s Social Rules](https://www.recurse.com/manual#sec-environment), and the [anti-harassment policy from the Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy). 
-
+EDGI's Code of Conduct can be found here: https://docs.google.com/document/d/1zqFPVjQ__x3tfcSlir-jeO7O-mcCh4oKyNNlJEpJMOU/edit?usp=sharing


### PR DESCRIPTION
Pros: All the other repos link to this one doc, which now links to the CoC that's just been adopted.

Cons: Might be a couple of clicks to get to the actual CoC, GDocs has some accessibility issues